### PR TITLE
chore(dependabot): assign PRs to me for notifications

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 99
-  reviewers:
+  assignees:
   - diogopms
   ignore:
   - dependency-name: alpine


### PR DESCRIPTION
Adds `assignees: [diogopms]` so every future Dependabot PR is assigned to me and I get notified.