### PR TITLE
chore: add CODEOWNERS for automatic review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @diogopms


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @diogopms` so every future PR automatically requests a review from me.