### PR TITLE
ci: align release workflow with canonical template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,12 @@
 name: Release
 
-# Releases are NOT cut on merge to master — pushes only run CI.
+# Releases are NOT cut on merge to master - pushes to master only run CI (ci.yml).
 # Instead this job runs on a schedule (monthly): it determines the next
 # version from the Conventional Commits since the last tag. Only if there is a
 # release-worthy change (a feat/fix/breaking-change commit) does it create the
 # git tag, build and push the production Docker image to the GitHub Container
 # Registry (ghcr.io), and cut a GitHub Release. If nothing releasable has landed
-# since the last tag, `new_version` is empty and every release step is skipped —
+# since the last tag, `new_version` is empty and every release step is skipped -
 # a no-op run.
 #
 # To FORCE a release (e.g. after a docs-only or chore change), trigger it
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: master
           # Full history is required so the tagging action can read previous tags
@@ -91,11 +91,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.tag.outputs.new_version
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         if: steps.tag.outputs.new_version
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build and push image
         if: steps.tag.outputs.new_version
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -118,7 +118,7 @@ jobs:
 
       - name: Create GitHub release
         if: steps.tag.outputs.new_version
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.new_tag }}
           name: ${{ steps.tag.outputs.new_tag }}


### PR DESCRIPTION
## Summary
Aligns .github/workflows/release.yml with the canonical release template used across the other repos (same wording and current action versions: checkout@v7, buildx@v4, login@v4, build-push@v7, gh-release@v3). Branch references stay on `master`. No behavioural change to the release logic: monthly schedule, Conventional-Commit-driven tag, ghcr.io image, GitHub Release.

## Test plan
- Diffed against the canonical template: only the default-branch name differs where the repo uses `master`.
- After merge: `gh workflow run release.yml -f bump=patch` exercises the full release.