### PR TITLE
ci: point release workflow at main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-# Releases are NOT cut on merge to master - pushes to master only run CI (ci.yml).
+# Releases are NOT cut on merge to main - pushes to main only run CI (ci.yml).
 # Instead this job runs on a schedule (monthly): it determines the next
 # version from the Conventional Commits since the last tag. Only if there is a
 # release-worthy change (a feat/fix/breaking-change commit) does it create the
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: master
+          ref: main
           # Full history is required so the tagging action can read previous tags
           # and compute the next semantic version.
           fetch-depth: 0
@@ -71,7 +71,7 @@ jobs:
           # bump=patch|minor|major forces that bump even on a docs-only change.
           # A feat/fix/breaking-change commit always wins over this fallback.
           default_bump: ${{ (github.event_name == 'workflow_dispatch' && inputs.bump != 'auto') && inputs.bump || false }}
-          release_branches: master
+          release_branches: main
 
       - name: Compute image metadata
         if: steps.tag.outputs.new_version


### PR DESCRIPTION
## Summary
Follow-up to #61 and the default-branch rename (master → main): release.yml is now the canonical template verbatim, with `ref`/`release_branches` on `main`.

## Test plan
- Diffed against the canonical template used across the other repos: identical.