### PR TITLE
ci: tag only after the image is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,14 @@
 name: Release
 
-# Releases are NOT cut on merge to main - pushes to main only run CI (ci.yml).
+# Releases are NOT cut on merge to main — pushes only run CI.
 # Instead this job runs on a schedule (monthly): it determines the next
 # version from the Conventional Commits since the last tag. Only if there is a
-# release-worthy change (a feat/fix/breaking-change commit) does it create the
-# git tag, build and push the production Docker image to the GitHub Container
-# Registry (ghcr.io), and cut a GitHub Release. If nothing releasable has landed
-# since the last tag, `new_version` is empty and every release step is skipped -
+# release-worthy change (a feat/fix/breaking-change commit) does it build and
+# push the production Docker image to the GitHub Container Registry (ghcr.io),
+# then create the git tag and cut a GitHub Release. The version is computed in
+# dry-run mode and the tag is created only after the image is published, so a
+# failed build never leaves a dangling tag behind. If nothing releasable has landed
+# since the last tag, `new_version` is empty and every release step is skipped —
 # a no-op run.
 #
 # To FORCE a release (e.g. after a docs-only or chore change), trigger it
@@ -72,6 +74,10 @@ jobs:
           # A feat/fix/breaking-change commit always wins over this fallback.
           default_bump: ${{ (github.event_name == 'workflow_dispatch' && inputs.bump != 'auto') && inputs.bump || false }}
           release_branches: main
+          # Compute the next version WITHOUT creating the tag here. The tag is
+          # created later by the release step, only after the image is pushed,
+          # so a failed build never leaves an orphan tag behind.
+          dry_run: true
 
       - name: Compute image metadata
         if: steps.tag.outputs.new_version
@@ -121,5 +127,9 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.new_tag }}
+          # Create the tag on the checked-out branch tip now that the image is
+          # published. This is the point at which the version tag comes into
+          # existence (the version step above ran in dry-run mode).
+          target_commitish: main
           name: ${{ steps.tag.outputs.new_tag }}
           body: ${{ steps.tag.outputs.changelog }}


### PR DESCRIPTION
## Summary
Adopts the safer release semantics already used by `postgres-gcs-backup` and `mongodb-gcs-backup`, making the release workflow identical across every Docker-releasing repo.

The change: the version is computed in **dry-run mode**, the image is built and pushed to ghcr.io, and only then is the git tag created (via `target_commitish` on the release step). Previously the tag was created first, so a failed image build left a dangling version tag behind that the next run would then skip past.

Everything else is unchanged: monthly schedule, manual dispatch with a forced bump, Conventional-Commit version rules, the same ghcr.io image tags and the same GitHub Release.

## Test plan
- Workflow parses as valid YAML and is byte-identical to the shared template.
- After merge: `gh workflow run release.yml -f bump=patch` exercises the full path (dry-run version, image push, tag, release).