### PR TITLE
feat!: multi-arch image on Monit 6.0.0 with CI pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.dockerignore
+Dockerfile
+docker-compose.yaml
+LICENSE
+README.md
+monitrc
+samples/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "10:00"
-  open-pull-requests-limit: 99
-  assignees:
-  - diogopms
-  ignore:
-  - dependency-name: alpine
-    versions:
-    - 3.13.3
-    - 3.13.4
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: monthly
+    assignees:
+      - diogopms
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    assignees:
+      - diogopms

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+# Summary
+
+<!-- What does this PR change and why? -->
+
+# Changes
+
+-
+
+# Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, ... — `feat!:`/`BREAKING CHANGE` for major bumps)
+- [ ] CI is green (Dockerfile lint, shell lint, image build, smoke tests)
+- [ ] README updated if behavior, env vars, or usage changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+# Verification gate only — releases are cut by the Release workflow on a
+# schedule (see release.yml). Runs on every pull request and on pushes to
+# main: lints the Dockerfile and shell scripts, builds the image (single
+# arch, no push) and smoke-tests the resulting container.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.3.0
+        with:
+          dockerfile: Dockerfile
+
+      - name: Lint shell scripts
+        run: shellcheck docker-entrypoint.sh slack pushover
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: true
+          tags: monit-ci:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test — monit runs
+        run: docker run --rm monit-ci:${{ github.sha }} monit -V
+
+      - name: Smoke test — sample config is valid
+        run: |
+          docker run --rm \
+            -v "$PWD/samples/monitrc:/etc/monitrc" \
+            monit-ci:${{ github.sha }} \
+            monit -t -c /etc/monitrc_root

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,11 @@ jobs:
             echo "tags=$IMAGE:$VERSION,$IMAGE:$MAJOR.$MINOR,$IMAGE:$MAJOR,$IMAGE:latest"
           } >> "$GITHUB_OUTPUT"
 
+      # QEMU lets buildx cross-compile the arm64 variant on the amd64 runner.
+      - name: Set up QEMU
+        if: steps.tag.outputs.new_version
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         if: steps.tag.outputs.new_version
         uses: docker/setup-buildx-action@v4
@@ -183,6 +188,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,43 @@
+# syntax=docker/dockerfile:1
+
+FROM alpine:3.24.1 AS builder
+
+ENV MONIT_VERSION=6.0.0 \
+    MONIT_SHA256=ddacd2a8120aeb2351e4486ee04a17782b5004aee99f2041d829bc4dcf2a5b3b \
+    MONIT_URL=https://mmonit.com/monit/dist
+
+WORKDIR /opt/src
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache gcc musl-dev make openssl-dev zlib-dev && \
+    wget -q "${MONIT_URL}/monit-${MONIT_VERSION}.tar.gz" && \
+    echo "${MONIT_SHA256}  monit-${MONIT_VERSION}.tar.gz" > monit.sha256 && \
+    sha256sum -c monit.sha256 && \
+    tar xzf "monit-${MONIT_VERSION}.tar.gz"
+
+WORKDIR /opt/src/monit-${MONIT_VERSION}
+
+RUN ./configure --prefix=/opt/monit --without-pam && \
+    make -j"$(nproc)" && \
+    make install
+
 FROM alpine:3.24.1
 
-LABEL maintainer="Diogo Serrano <info@diogoserrano.com>"
-
-# monit environment variables
-ENV MONIT_VERSION=5.26.0 \
+ENV MONIT_VERSION=6.0.0 \
     MONIT_HOME=/opt/monit \
-    MONIT_URL=https://mmonit.com/monit/dist \
     PATH=$PATH:/opt/monit/bin
 
+# hadolint ignore=DL3018
+RUN apk add --no-cache bash ca-certificates curl python3
+
+COPY --from=builder /opt/monit /opt/monit
 COPY slack /bin/slack
 COPY pushover /bin/pushover
-
-# Compile and install monit
-RUN \
-    apk add --update gcc musl-dev make bash python3 curl libressl-dev file zlib-dev && \
-    mkdir -p /opt/src; cd /opt/src && \
-    wget -qO- ${MONIT_URL}/monit-${MONIT_VERSION}.tar.gz | tar xz && \
-    cd /opt/src/monit-${MONIT_VERSION} && \
-    ./configure --prefix=${MONIT_HOME} --without-pam && \
-    make && make install && \
-    apk del gcc musl-dev make file zlib-dev && \
-    rm -rf /var/cache/apk/* /opt/src
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s /usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 
 EXPOSE 2812
 
-COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s /usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["monit", "-I", "-B", "-c", "/etc/monitrc_root"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Diogo Serrano
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,64 +1,89 @@
-# Monit - Docker/Kubernetes - UNIX Systems Management
+# monit-docker
 
-Run Monit inside docker ( )
+[![Release](https://github.com/diogopms/monit-docker/actions/workflows/release.yml/badge.svg)](https://github.com/diogopms/monit-docker/actions/workflows/release.yml)
+[![CI](https://github.com/diogopms/monit-docker/actions/workflows/ci.yml/badge.svg)](https://github.com/diogopms/monit-docker/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/diogopms/monit-docker)](https://github.com/diogopms/monit-docker/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-[![Monit](https://mmonit.com/monit/img/logo.png)](https://mmonit.com/monit/)
+[Monit](https://mmonit.com/monit/) packaged as a small Alpine-based Docker image, with built-in [Slack](https://slack.com) and [Pushover](https://pushover.net) notification scripts.
 
-[Monit](https://mmonit.com/monit/) is a free open source utility for managing and monitoring, processes, programs, files, directories and filesystems on a UNIX system. Monit conducts automatic maintenance and repair and can execute meaningful causal actions in error situations.
+Monit is a free open-source utility for managing and monitoring processes, programs, files, directories and filesystems on UNIX systems. It conducts automatic maintenance and repair and can execute meaningful causal actions in error situations.
 
-## Supported architectures
-
-- amd64
-- arm32v6 (Raspberry Pi) [diogopms/monit-docker-kubernetes:arm32v6-latest](https://hub.docker.com/r/diogopms/monit-docker-kubernetes/tags?page=1&name=arm)
-
-## Docker setup
-
-Install docker: https://docs.docker.com/engine/installation/
-Install docker compose: https://docs.docker.com/compose/install/
-Docker documentation: https://docs.docker.com/
-
-### Build-in docker image
-
-- build docker image `docker build -t monit .`
-- start monit: `docker run -ti -p 2812:2812 -v $(pwd)/monitrc:/etc/monitrc monit`
-
-## ENV VARS
-
-| ENVs            	| Description                                              	|
-|-----------------	|----------------------------------------------------------	|
-| SLACK_URL       	| Webhook url for slack notifications (required for slack) 	|
-| PUSH_OVER_TOKEN 	| Push over api token (required for pushover)              	|
-| PUSH_OVER_USER  	| Push over api user (requiredfor pushover)                	|
-| DEBUG           	| If set with 1 it will put monit in verbose mode          	|
-
-### Docker Hub image
-
-- pull docker image from docker hub: `docker pull diogopms/monit-docker-kubernetes`
-- start monit: `docker run -ti -p 2812:2812 -v $(pwd)/monitrc:/etc/monitrc diogopms/monit-docker-kubernetes`
-- create a docker container:
+## Image
 
 ```
-#Normal mode (support slack and pushover)
-docker run -it \
+ghcr.io/diogopms/monit-docker
+```
+
+| Tag | Meaning |
+|---|---|
+| `latest` | Latest release |
+| `X` | Latest release in that major version |
+| `X.Y` | Latest release in that minor version |
+| `X.Y.Z` | Exact release |
+
+Supported platforms: `linux/amd64`, `linux/arm64` (Raspberry Pi 3/4/5 with a 64-bit OS).
+
+## Quick start
+
+Write a `monitrc` (see [samples/](samples/) and the examples below), then:
+
+```sh
+docker run -d \
   -p 2812:2812 \
-  -v $(pwd)/monitrc:/etc/monitrc \
+  -v "$(pwd)/monitrc:/etc/monitrc" \
+  ghcr.io/diogopms/monit-docker
+```
+
+Or with Docker Compose ([docker-compose.yaml](docker-compose.yaml)):
+
+```yaml
+services:
+  monit:
+    image: ghcr.io/diogopms/monit-docker:latest
+    container_name: monit
+    environment:
+      - TZ=Europe/Lisbon
+    volumes:
+      - ./monitrc:/etc/monitrc
+    ports:
+      - 2812:2812
+    restart: unless-stopped
+```
+
+To use Monit's web interface, uncomment `set httpd port 2812` in your `monitrc` and open http://localhost:2812.
+
+## Configuration
+
+Mount your Monit control file at `/etc/monitrc`. The entrypoint copies it to a root-owned file with `0700` permissions before starting Monit (Monit refuses configs with looser permissions), so you don't need to fix permissions on the host.
+
+### Environment variables
+
+| Variable | Description |
+|---|---|
+| `SLACK_URL` | Slack incoming-webhook URL (required for `/bin/slack`) |
+| `PUSH_OVER_TOKEN` | Pushover API token (required for `/bin/pushover`) |
+| `PUSH_OVER_USER` | Pushover API user key (required for `/bin/pushover`) |
+| `DEBUG` | Set to `1` to run Monit in verbose mode |
+
+```sh
+docker run -d \
+  -p 2812:2812 \
+  -v "$(pwd)/monitrc:/etc/monitrc" \
   -e "SLACK_URL=<SLACK_URL>" \
   -e "PUSH_OVER_TOKEN=<PUSH_OVER_TOKEN>" \
   -e "PUSH_OVER_USER=<PUSH_OVER_USER>" \
-  diogopms/monit-docker-kubernetes
-
-#Debug mode
-docker run -it \
-  -p 2812:2812 \
-  -v $(pwd)/monitrc:/etc/monitrc \
-  -e "SLACK_URL=<SLACK_URL>" \
-  -e "PUSH_OVER_TOKEN=<PUSH_OVER_TOKEN>" \
-  -e "PUSH_OVER_USER=<PUSH_OVER_USER>" \
-  -e "DEBUG=1" \
-  diogopms/monit-docker-kubernetes
+  ghcr.io/diogopms/monit-docker
 ```
 
-### Example monitrc (Slack)
+## Notifications
+
+The image ships two notification scripts you can call from `exec` actions in your `monitrc`:
+
+- `/bin/slack` — posts the Monit event to a Slack incoming webhook (`SLACK_URL`)
+- `/bin/pushover` — sends the Monit event via Pushover (`PUSH_OVER_TOKEN` + `PUSH_OVER_USER`)
+
+### Example `monitrc` (Slack)
 
 ```
 set daemon 20
@@ -74,10 +99,9 @@ check host www.google.com with address www.google.com
       for 2 cycles
   then exec "/bin/slack"
     else if succeeded then exec "/bin/slack"
-EOF
 ```
 
-### Example monitrc (Pushover)
+### Example `monitrc` (Pushover)
 
 ```
 set daemon 20
@@ -93,16 +117,32 @@ check host www.google.com with address www.google.com
       for 2 cycles
   then exec "/bin/pushover"
     else if succeeded then exec "/bin/pushover"
-EOF
 ```
 
-### Supported notifications
+More examples in [samples/](samples/).
 
-- [Slack](https://www.slack.com)
-- [Pushover](https://pushover.net)
+## Building locally
 
-### Kubernetes
+```sh
+docker build -t monit .
+docker run -d -p 2812:2812 -v "$(pwd)/monitrc:/etc/monitrc" monit
+```
 
-### Troubleshooting
+The build compiles Monit from source (checksum-verified) in a builder stage and ships only the compiled binary plus runtime dependencies.
 
-If when starting Monit returns the following message: `The control file '/etc/monitrc' permission 0755 is wrong, maximum 0700 allowed`, simply give the appropriate permissions to _monitrc_: `chmod 700 monitrc`.
+## Releases & versioning
+
+Versions follow [SemVer](https://semver.org/) driven by [Conventional Commits](https://www.conventionalcommits.org/):
+
+- A scheduled workflow runs monthly; if any `feat`/`fix`/breaking commit landed since the last tag, it builds and pushes the multi-arch image to GHCR, then creates the git tag and GitHub Release.
+- `fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE` → major. Anything else does not release.
+- A release can be forced manually: Actions → Release → "Run workflow" → pick a bump level.
+
+## Troubleshooting
+
+- **`The control file '/etc/monitrc' permission 0755 is wrong, maximum 0700 allowed`** — the entrypoint normally handles this; if you run Monit against the mounted file directly, run `chmod 700 monitrc` on the host.
+- **Verbose logging** — set `DEBUG=1` to start Monit with `-v`.
+
+## License
+
+[MIT](LICENSE)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,12 +1,9 @@
 ---
-version: "3.8"
 services:
   monit:
-    image: diogopms/monit-docker-kubernetes:latest
+    image: ghcr.io/diogopms/monit-docker:latest
     container_name: monit
     environment:
-      - PUID=1000
-      - PGID=1000
       - TZ=Europe/Lisbon
     volumes:
       - ./monitrc:/etc/monitrc

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,17 +1,21 @@
 #!/bin/sh
+set -e
 
-echo "Setting up monitrc"
-chmod 700 /etc/monitrc
-cp /etc/monitrc /etc/monitrc_root
-chown root:root /etc/monitrc_root
+# Monit refuses configs that are readable by anyone but the owner, so tighten
+# the mounted file's permissions and run from a root-owned copy (the mount
+# usually belongs to a host user, not root).
+if [ -f /etc/monitrc ]; then
+  echo "Setting up monitrc"
+  chmod 700 /etc/monitrc
+  cp /etc/monitrc /etc/monitrc_root
+  chown root:root /etc/monitrc_root
+fi
 
 echo "Removing prior PID file"
 rm -f /var/run/monit.pid
 
-if [ "$DEBUG" = "1" ]
-then
+if [ "$DEBUG" = "1" ]; then
   exec monit -I -B -v -c /etc/monitrc_root
-else
-
-  exec "$@"
 fi
+
+exec "$@"

--- a/pushover
+++ b/pushover
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z "${PUSH_OVER_TOKEN}" || -z "${PUSH_OVER_USER}" ]]; then
-  echo "Required credentials <PUSH_OVER_TOKEN|PUSH_OVER_USER"
+  echo "Missing PUSH_OVER_TOKEN or PUSH_OVER_USER"
   exit 1
 fi
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,27 +1,29 @@
-# Need help?
+# Samples
 
-## Normal mode
+`monitrc` in this directory is a minimal working config: it checks
+https://www.google.com and notifies Slack on state changes.
+
+## Run it
 
 ```sh
 docker run -it \
   -p 2812:2812 \
-  -v $(pwd)/monitrc:/etc/monitrc \
+  -v "$(pwd)/monitrc:/etc/monitrc" \
   -e "SLACK_URL=<SLACK_URL>" \
   -e "PUSH_OVER_TOKEN=<PUSH_OVER_TOKEN>" \
   -e "PUSH_OVER_USER=<PUSH_OVER_USER>" \
-  -e "DEBUG=1" \
-  diogopms/monit-docker-kubernetes
+  ghcr.io/diogopms/monit-docker
 ```
 
-## Debug
+## Debug mode
+
+Add `-e "DEBUG=1"` to run Monit in verbose mode:
 
 ```sh
 docker run -it \
   -p 2812:2812 \
-  -v $(pwd)/monitrc:/etc/monitrc \
+  -v "$(pwd)/monitrc:/etc/monitrc" \
   -e "SLACK_URL=<SLACK_URL>" \
-  -e "PUSH_OVER_TOKEN=<PUSH_OVER_TOKEN>" \
-  -e "PUSH_OVER_USER=<PUSH_OVER_USER>" \
-  -e "DEBUG=0" \
-  diogopms/monit-docker-kubernetes
+  -e "DEBUG=1" \
+  ghcr.io/diogopms/monit-docker
 ```

--- a/samples/monitrc
+++ b/samples/monitrc
@@ -11,4 +11,3 @@ check host www.google.com with address www.google.com
       for 2 cycles
   then exec "/bin/slack"
     else if succeeded then exec "/bin/slack"
-EOF

--- a/slack
+++ b/slack
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z "${SLACK_URL}" ]]; then
-  echo "Missing Slack url"
+  echo "Missing SLACK_URL"
   exit 1
 fi
 
@@ -22,6 +22,6 @@ PAYLOAD="{
   ]
 }"
 
-curl -s -X POST --data-urlencode "payload=$PAYLOAD" $SLACK_URL
+curl -s -X POST --data-urlencode "payload=$PAYLOAD" "$SLACK_URL"
 
 exit 0


### PR DESCRIPTION
# Summary

Full refactor aligning this repo with the CI/release conventions used in my other projects, plus proper public documentation.

**BREAKING CHANGE**: Monit upgraded 5.26.0 → 6.0.0; the image is published exclusively to `ghcr.io/diogopms/monit-docker` (all Docker Hub references removed).

# Changes

- **Dockerfile**: multi-stage build — Monit 6.0.0 compiled from a sha256-verified tarball in a builder stage; runtime stage ships only the binary plus `bash`/`curl`/`python3`/`ca-certificates`. hadolint-clean.
- **CI (new)**: `ci.yml` on every PR and push to main — hadolint, shellcheck, buildx image build with GHA cache, and container smoke tests (`monit -V`, sample config `monit -t`).
- **Release**: adds QEMU + `platforms: linux/amd64,linux/arm64` — the published image is now multi-arch (covers Raspberry Pi 3/4/5 on 64-bit OS).
- **Entrypoint**: `set -e`, tolerates a missing `/etc/monitrc` (so `monit -V` etc. work without a mount); chmod/copy behavior unchanged when the config is mounted.
- **README**: rewritten as public docs for the GHCR image — badges, supported tags/platforms, quick start, env vars, Slack/Pushover examples, release process, troubleshooting. Samples fixed (stray `EOF` in `monitrc`, outdated image name, swapped debug flags).
- **Housekeeping**: MIT LICENSE, `.dockerignore`, PR template, dependabot now watches docker + github-actions monthly, compose file points at the GHCR image, shellcheck fixes in `slack`/`pushover`.

# Verification

- `docker build` + `monit -V` → 6.0.0 (arm64 native)
- `docker buildx build --platform linux/amd64` → compiles under QEMU
- Sample config validation via entrypoint → `Control file syntax OK`
- `hadolint Dockerfile` and `shellcheck docker-entrypoint.sh slack pushover` clean
- Tarball checksum matches the official `monit-6.0.0.tar.gz.sha256` from mmonit.com

# Release note

After merge, the first release should be cut manually with `gh workflow run release.yml -f bump=major` → `v2.0.0`, seeding the `v*` tag scheme (existing tags are `1.4`-style).